### PR TITLE
Fix warnings under -Wall -Wextra -pedantic

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 3.1.3)
 
 enable_testing()
+set(CMAKE_CXX_STANDARD 17)
 
 project("poly_vector" VERSION 0.1 LANGUAGES CXX)
 


### PR DESCRIPTION
Hi,
I have been adopting the library to store instructions in expression in a compiler framework. Thanks for the great library, however, gcc (gcc 10) reports several warnings on poly_vector under -Wall -Wextra -pedantic. This pull request fix the warnings and pass all the test. 
Thanks.